### PR TITLE
Fix trailing slash bug

### DIFF
--- a/code/api/urls.py
+++ b/code/api/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
     path('author/<author_id>/posts/<post_id>', PostView.as_view(), name='post'),
     path('author/<author_id>/posts/<post_id>/likes', PostLikesView.as_view(), name='post_likes'),
     path('author/<author_id>/posts/<post_id>/comments', PostCommentsView.as_view(), name='post_comments'),
+    path('author/<author_id>/posts/<post_id>/comments/', PostCommentsView.as_view(), name='post_comments'),
     path('author/<author_id>/posts/<post_id>/comments/<comment_id>/likes', CommentLikesView.as_view(), name='comment_likes'),
+    path('author/<author_id>/inbox', InboxView.as_view(), name='inbox'),
     path('author/<author_id>/inbox/', InboxView.as_view(), name='inbox'),
 ]


### PR DESCRIPTION
Minor bug to fix error when making POST to `/author/1/inbox` instead of `/author/1/inbox/`. Django was getting angry and telling me that couldn't redirect the post. This fix lets POSTs go to both routes.

```
RuntimeError: You called this URL via POST, but the URL doesn't end in a slash and you have APPEND_SLASH set. Django can't redirect to the slash URL while maintaining POST data. Change your form to point to 127.0.0.1:8000/api/author/1/inbox/ (note the trailing slash), or set APPEND_SLASH=False in your Django settings.
```