### PR TITLE
Put comment and like icons beside each other

### DIFF
--- a/code/socialDistribution/templates/tagtemplates/post.html
+++ b/code/socialDistribution/templates/tagtemplates/post.html
@@ -19,43 +19,48 @@
             class="rounded w-100 h-100 mx-auto">
         {% endif %}
     </div>
-    <div class="card-footer bg-white d-flex justify-content-between">
-        <span>
-            {% if isLiked %}
-            <form method="post" action="{% url 'socialDistribution:likePost' post.id %}" class="d-flex">
-                {% csrf_token %}
-                <button class="btn btn-secondary"><i class="fas fa-thumbs-up"></i></button>
-            </form>
+    <div class="card-footer bg-white">
+        <div class="d-flex flex-column">
+            <p class="px-2">
+                {{ likeText }}
+            </p>
+            <div class="d-flex justify-content-between">
+                <div class="d-flex flex-row">
+                    {% if isLiked %}
+                    <form method="post" action="{% url 'socialDistribution:likePost' post.id %}" class="d-flex">
+                        {% csrf_token %}
+                        <button class="btn btn-secondary mx-2"><i class="fas fa-thumbs-up"></i></button>
+                    </form>
 
-            {% else %}
-            <form method="post" action="{% url 'socialDistribution:likePost' post.id %}" class="d-flex">
-                {% csrf_token %}
-                <button class="btn btn-primary"><i class="fas fa-thumbs-up"></i></button>
-            </form>
+                    {% else %}
+                    <form method="post" action="{% url 'socialDistribution:likePost' post.id %}" class="d-flex">
+                        {% csrf_token %}
+                        <button class="btn btn-primary mx-2"><i class="fas fa-thumbs-up"></i></button>
+                    </form>
 
-            {% endif %}
+                    {% endif %}
 
-            {{ likeText }}
+                    <!-- Comment Icon -->
+                    <a href="{% url 'socialDistribution:commentPost' post.id %}"> <button class="btn btn-secondary"><i
+                                class="fas fa-comment"></i></button></a>
 
-            <!-- Comment Icon -->
-            <a href="{% url 'socialDistribution:commentPost' post.id %}"> <button class="btn btn-secondary"><i
-                        class="fas fa-comment"></i></button></a>
+                </div>
 
-        </span>
-
-        {% if isAuthor %}
-        <span>
-            <!-- Launch Edit Modal -->
-            <button type="button" class="btn btn btn-secondary" data-bs-toggle="modal"
-                data-bs-target="#edit_post_modal">
-                <i class="fas fa-edit"></i></button>
-            </button>
-            <!-- Launch Delete Modal -->
-            <button type="button" class="btn btn btn-danger" data-bs-toggle="modal" data-bs-target="#delete_post_modal">
-                <i class="fas fa-trash-alt"></i></button>
-            </button>
-        </span>
-        {% endif %}
+                {% if isAuthor %}
+                <span>
+                    <!-- Launch Edit Modal -->
+                    <button type="button" class="btn btn btn-secondary" data-bs-toggle="modal"
+                        data-bs-target="#edit_post_modal">
+                        <i class="fas fa-edit"></i></button>
+                    </button>
+                    <!-- Launch Delete Modal -->
+                    <button type="button" class="btn btn btn-danger" data-bs-toggle="modal" data-bs-target="#delete_post_modal">
+                        <i class="fas fa-trash-alt"></i></button>
+                    </button>
+                </span>
+                {% endif %}
+            </div>
+        </div>
     </div>
     {% load modal %}
     <form method="POST" action="{% url 'socialDistribution:deletePost' post.id %}">


### PR DESCRIPTION
Fix the like & comments icons layout in the post cards

Small PR (sorry for the last min review). I thought this was being handled in a different PR.

![image](https://user-images.githubusercontent.com/59672031/139378001-1c193ead-3e27-42b4-8de8-c04898cd9e7d.png)

### It's currently like this in master (below)

![image](https://user-images.githubusercontent.com/59672031/139378521-be3523cb-8f2c-4f72-b5e5-eef56afc71ab.png)
