### PR TITLE
Restructure models

### DIFF
--- a/code/socialDistribution/builders.py
+++ b/code/socialDistribution/builders.py
@@ -1,6 +1,7 @@
-from .models import *
 from mixer.backend.django import mixer
-from datetime import datetime
+from datetime import datetime, timezone
+
+from .models import *
 
 
 class PostBuilder:

--- a/code/socialDistribution/models/__init__.py
+++ b/code/socialDistribution/models/__init__.py
@@ -1,0 +1,6 @@
+# https://docs.djangoproject.com/en/3.2/topics/db/models/#organizing-models-in-a-package
+
+from .common import Post, Author
+from .category import Category
+from .comment import Comment
+from .inbox import Inbox

--- a/code/socialDistribution/models/__init__.py
+++ b/code/socialDistribution/models/__init__.py
@@ -1,6 +1,10 @@
+""" Module for all models in socialDistribution app. """
+
+# Django Software Foundation, "Organizing models in a package", 2021-10-30
 # https://docs.djangoproject.com/en/3.2/topics/db/models/#organizing-models-in-a-package
 
-from .common import Post, Author
+from .author import Author
+from .post import Post
 from .category import Category
 from .comment import Comment
 from .inbox import Inbox

--- a/code/socialDistribution/models/author.py
+++ b/code/socialDistribution/models/author.py
@@ -1,10 +1,6 @@
-
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.contrib.auth.models import User
-from django.db.models import Q, manager
 from datetime import *
-import timeago
 
 from cmput404.constants import HOST, API_PREFIX
 
@@ -42,26 +38,6 @@ class Author(models.Model):
         """
         return self.followers.filter(pk=author.id).exists() and \
             author.followers.filter(pk=self.id).exists()
-
-    # depreciated
-    # def get_visible_posts_to(self, author):
-    #     """ 
-    #         @depreciated due to too much coupling between posts and author
-    #         author to author method yet still relies on Post
-
-    #         Returns valid posts
-    #     """
-    #     visible_posts = None
-    #     if author.id == self.id:
-    #         visible_posts = Post.objects.filter(author__pk=author.id)
-    #     elif self.is_friends_with(author):
-    #         visible_posts = Post.objects.filter(
-    #             author__pk=self.id).exclude(visibility=Post.PRIVATE)
-    #     else:
-    #         visible_posts = Post.objects.filter(
-    #             author__pk=self.id, visibility=Post.PUBLIC)
-
-    #     return visible_posts.order_by('-pub_date')[:]
 
     def __str__(self):
         return self.displayName

--- a/code/socialDistribution/models/author.py
+++ b/code/socialDistribution/models/author.py
@@ -1,0 +1,85 @@
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.contrib.auth.models import User
+from django.db.models import Q, manager
+from datetime import *
+import timeago
+
+from cmput404.constants import HOST, API_PREFIX
+
+
+class Author(models.Model):
+    '''
+    Author model:
+        user                Author's corresponding Django User (text)
+        username            Author's username (text)
+        displayName         Author's displayName (text)
+        githubUrl           Author's github url (text)
+        profileImageUrl     Author's profile image url (text)
+
+        posts               Posts created by the author
+        friend_requests     fksdjfskl;jfaskdf
+        followers           Author's followers (array)
+    '''
+    user = models.OneToOneField(User, null=True, on_delete=models.CASCADE)
+    username = models.CharField(max_length=50, default='', unique=True)
+    displayName = models.CharField(max_length=50)
+    githubUrl = models.CharField(max_length=50, null=True)
+    profileImageUrl = models.CharField(max_length=50, null=True)
+
+    followers = models.ManyToManyField('Author', blank=True)
+
+    def has_follower(self, author):
+        """
+        Returns True if an author follows a user, False otherwise 
+        """
+        return self.followers.filter(pk=author.id).exists()
+
+    def is_friends_with(self, author):
+        """
+        Returns True if an author is friends wtih a user, False otherwise 
+        """
+        return self.followers.filter(pk=author.id).exists() and \
+            author.followers.filter(pk=self.id).exists()
+
+    # depreciated
+    # def get_visible_posts_to(self, author):
+    #     """ 
+    #         @depreciated due to too much coupling between posts and author
+    #         author to author method yet still relies on Post
+
+    #         Returns valid posts
+    #     """
+    #     visible_posts = None
+    #     if author.id == self.id:
+    #         visible_posts = Post.objects.filter(author__pk=author.id)
+    #     elif self.is_friends_with(author):
+    #         visible_posts = Post.objects.filter(
+    #             author__pk=self.id).exclude(visibility=Post.PRIVATE)
+    #     else:
+    #         visible_posts = Post.objects.filter(
+    #             author__pk=self.id, visibility=Post.PUBLIC)
+
+    #     return visible_posts.order_by('-pub_date')[:]
+
+    def __str__(self):
+        return self.displayName
+
+    def as_json(self):
+        return {
+            "type": "author",
+            # ID of the Author
+            "id": f"http://{HOST}/{API_PREFIX}/author/{self.id}",
+            # the home host of the author
+            "host": f'http://{HOST}/{API_PREFIX}/',
+            # the display name of the author
+            "displayName": self.displayName,
+            # url to the authors profile
+            "url": f"http://{HOST}/{API_PREFIX}/author/{self.id}",
+            # HATEOS url for Github API
+            "github": self.githubUrl,
+            # Image from a public domain
+            # #TODO
+            "profileImage": self.profileImageUrl
+        }

--- a/code/socialDistribution/models/category.py
+++ b/code/socialDistribution/models/category.py
@@ -1,0 +1,16 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.contrib.auth.models import User
+from datetime import *
+
+from cmput404.constants import HOST, API_PREFIX
+
+class Category(models.Model):
+    '''
+    Categories model:
+        id                  Auto-generated id
+        category            Category name
+        post                reference to post (Many-to-One relationship)
+    '''
+    category = models.CharField(max_length=50)
+    post = models.ForeignKey('Post', on_delete=models.CASCADE)

--- a/code/socialDistribution/models/category.py
+++ b/code/socialDistribution/models/category.py
@@ -1,9 +1,4 @@
-from django.core.exceptions import ValidationError
 from django.db import models
-from django.contrib.auth.models import User
-from datetime import *
-
-from cmput404.constants import HOST, API_PREFIX
 
 class Category(models.Model):
     '''

--- a/code/socialDistribution/models/comment.py
+++ b/code/socialDistribution/models/comment.py
@@ -1,0 +1,46 @@
+from django.db import models
+from datetime import *
+import timeago
+
+from cmput404.constants import HOST, API_PREFIX
+
+class Comment(models.Model):
+    '''
+    Comment model:
+        author              Comment author (reference to author)
+        content_type        Markdown or Text
+        comment             Comment content (markdown or text)
+        pub_date            Published date (datetime)
+        post                Post related to the comment (reference to post)
+        id                  Auto-generated id
+    '''
+    class CommentContentType(models.TextChoices):
+        PLAIN = 'PL', 'text/plain'
+        MARKDOWN = 'MD', 'text/markdown'
+
+    author = models.ForeignKey('Author', on_delete=models.CASCADE)
+    content_type = models.CharField(
+        max_length=2,
+        choices=CommentContentType.choices
+    )
+    comment = models.CharField(max_length=200)
+
+    post = models.ForeignKey('Post', on_delete=models.CASCADE)
+    pub_date = models.DateTimeField()
+
+    def when(self):
+        '''
+        Returns string describing when the comment was created
+        '''
+        now = datetime.now(timezone.utc)
+        return timeago.format(self.pub_date, now)
+
+    def as_json(self):
+        return {
+            "type": "comment",
+            "author": self.author.as_json(),
+            "comment": self.comment,
+            "contentType": "text/markdown",
+            "published": str(self.pub_date),
+            "id": f"http://{HOST}/{API_PREFIX}/author/{self.post.author.id}/posts/{self.post.id}/comments/{self.id}",
+        }

--- a/code/socialDistribution/models/inbox.py
+++ b/code/socialDistribution/models/inbox.py
@@ -1,0 +1,34 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+from datetime import *
+
+from cmput404.constants import HOST, API_PREFIX
+
+class Inbox(models.Model):
+    '''
+    Inbox model:
+        author          author associated with the inbox (primary key)
+        posts           posts pushed to this inbox (M2M)
+        followRequests  follow requests pushed to this inbox (M2M)
+    '''
+    author = models.OneToOneField(
+        'Author', on_delete=models.CASCADE, primary_key=True)
+    posts = models.ManyToManyField(
+        'Post', related_name='pushed_posts', blank=True)
+    follow_requests = models.ManyToManyField(
+        'Author', related_name='follow_requests', blank=True)
+
+    def has_req_from(self, author):
+        """
+        Returns True if the user has a request from a specific author, False otherwise 
+        """
+        return self.follow_requests.filter(pk=author.id).exists()
+
+    def add_post(self, post):
+        """
+        Adds a pushed post
+        """
+        try:
+            self.posts.add(post)
+        except ValidationError:
+            raise

--- a/code/socialDistribution/models/inbox.py
+++ b/code/socialDistribution/models/inbox.py
@@ -1,8 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from datetime import *
-
-from cmput404.constants import HOST, API_PREFIX
 
 class Inbox(models.Model):
     '''

--- a/code/socialDistribution/models/post.py
+++ b/code/socialDistribution/models/post.py
@@ -113,52 +113,13 @@ class Post(models.Model):
     )
 
     visibility = models.CharField(
-        max_length=10, choices=VISIBILITY_CHOICES, default=PUBLIC)
+        max_length=10,
+        choices=VISIBILITY_CHOICES,
+        default=PUBLIC
+    )
     unlisted = models.BooleanField()
     likes = models.ManyToManyField(
         'Author', related_name="liked_post", blank=True)
-
-    # DEPRECIATED to remove coupling to Author
-    # Post does not need to query all authors
-    # @classmethod
-    # def get_all_friends_posts(cls, author):
-    #     '''
-    #     Get the posts created by friends of author
-    #     '''
-    #     followed_author_set = Author.objects.filter(followers__id=author.id)
-    #     follower_author_set = author.followers.all()
-    #     friends_set = followed_author_set and follower_author_set   # friends set
-    #     return cls.objects.filter(
-    #         unlisted=False,
-    #         author__in=friends_set,
-    #         visibility=Post.FRIENDS,
-    #     )
-
-    # @classmethod
-    # def get_latest_posts(cls, author):
-    #     '''
-    #     Get the author's posts and all the posts created by
-    #     author's friends
-    #     '''
-    #     # public posts not created by user
-    #     public_posts_set = cls.objects.filter(
-    #         unlisted=False,
-    #         visibility=Post.PUBLIC
-    #     ).exclude(author=author)
-
-    #     # all listed posts created by user
-    #     user_posts_set = cls.objects.filter(
-    #         unlisted=False,
-    #         author=author
-    #     )
-
-        
-
-    #     friends_posts_set = cls.get_all_friends_posts(author)
-    #     return public_posts_set.union(
-    #         friends_posts_set,
-    #         user_posts_set
-    #     ).order_by("-pub_date")[:]
 
     def get_comments_as_json(self):
         author_id = self.author.id

--- a/code/socialDistribution/tests.py
+++ b/code/socialDistribution/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from mixer.backend.django import mixer
-from datetime import timedelta
+from datetime import timedelta, timezone
 from .models import *
 from .builders import *
 

--- a/code/socialDistribution/tests.py
+++ b/code/socialDistribution/tests.py
@@ -21,6 +21,8 @@ class PostTest(TestCase):
         post = PostBuilder().likes(likes).build()
         self.assertTrue(post.total_likes() == likes)
 
+    # TODO test all PostQuerySet methods
+
 
 class CommentModelTests(TestCase):
 

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -254,7 +254,7 @@ def authors(request):
 
     # Django Software Foundation, "Generating aggregates for each item in a QuerySet", 2021-10-13
     # https://docs.djangoproject.com/en/3.2/topics/db/aggregation/#generating-aggregates-for-each-item-in-a-queryset
-    authors = Author.objects.all().annotate(Count("post"))
+    authors = Author.objects.all().annotate(Count("posts"))
     local_authors = [{
         "data": author,
         "type": "Local"
@@ -265,12 +265,20 @@ def authors(request):
 
 
 def author(request, author_id):
+    """ Display author's public profile and any posts created by the author that the current 
+        user is premitted to view.
     """
-        Returns an author's info 
-    """
+
     curr_user = Author.objects.get(user=request.user)
     author = get_object_or_404(Author, pk=author_id)
-    posts = author.get_visible_posts_to(curr_user)
+
+    # TODO: Should become an API request since won't know if author is local/remote
+    
+    if author.is_friends_with(curr_user):
+        posts = author.posts.listed().get_friend()
+    else:
+        posts = author.posts.listed().get_public()
+
     context = {
         'author': author,
         'author_type': 'Local',

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -55,8 +55,7 @@ def loginPage(request):
 
         if REQUIRE_SIGNUP_APPROVAL and not user.is_active:
             # user inactive
-            messages.info(
-                request, "Your account is currently pending approval. Please check back later.")
+            messages.info(request, "Your account is currently pending approval. Please check back later.")
         else:
             # user active, proceed to authentication
             user = authenticate(request, username=username, password=password)
@@ -440,8 +439,7 @@ def likePost(request, id):
             "object": f"http://{host}/author/{post.author.id}/posts/{id}"
         }
     # redirect request to remote/local api
-    make_request(
-        'POST', f'http://{host}/api/author/{post.author.id}/inbox/', json.dumps(like))
+    make_request('POST', f'http://{host}/api/author/{post.author.id}/inbox/', json.dumps(like))
     prev_page = request.META['HTTP_REFERER']
 
     if prev_page is None:

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -123,8 +123,7 @@ def register(request):
                 return HttpResponse("Sign up failed. Internal Server Error. Please Try again.", status=500)
 
             if REQUIRE_SIGNUP_APPROVAL:
-                messages.success(
-                    request, f'Account creation request sent to admin for {username}.')
+                messages.success(request, f'Account creation request sent to admin for {username}.')
             else:
                 messages.success(request, f'Account created for {username}.')
 
@@ -165,14 +164,14 @@ def home(request):
         if author.is_friends_with(other):
             friend_posts = other.posts.listed().get_friend()
             posts = posts.union(friend_posts)
-    
+
     context = {
         'author': author,
         'modal_type': 'post',
         'latest_posts': posts.chronological(),
         'error': False,
         'error_msg': ""
-    } 
+    }
 
     return render(request, 'home/index.html', context)
 
@@ -211,8 +210,7 @@ def befriend(request, author_id):
             messages.info(request, f'Already following {author.displayName}')
 
         if author.inbox.has_req_from(curr_user):
-            messages.info(
-                request, f'Follow request to {author.displayName} is pending')
+            messages.info(request, f'Follow request to {author.displayName} is pending')
 
         if author.id != curr_user.id:
             # send follow request
@@ -235,8 +233,6 @@ def un_befriend(request, author_id):
             messages.info(f'Couldn\'t un-befriend {author.displayName}')
 
     return redirect('socialDistribution:author', author_id)
-
-# @allowedUsers(allowed_roles=['author']) # just for demonstration
 
 
 def authors(request):
@@ -332,10 +328,8 @@ def posts(request, author_id):
                 post = Post.objects.create(
                     author_id=author_id,  # temporary
                     title=form.cleaned_data.get('title'),
-                    # will need to fix when moved to api
-                    source=request.build_absolute_uri(request.path),
-                    # will need to fix when moved to api
-                    origin=request.build_absolute_uri(request.path),
+                    source=request.build_absolute_uri(request.path),  # will need to fix when moved to api
+                    origin=request.build_absolute_uri(request.path),  # will need to fix when moved to api
                     description=form.cleaned_data.get('description'),
                     content_text=form.cleaned_data.get('content_text'),
                     visibility=form.cleaned_data.get('visibility'),
@@ -383,10 +377,8 @@ def editPost(request, id):
 
             try:
                 post.title = form.cleaned_data.get('title')
-                post.source = request.build_absolute_uri(
-                    request.path)    # will need to fix when moved to api
-                post.origin = request.build_absolute_uri(
-                    request.path)    # will need to fix when moved to api
+                post.source = request.build_absolute_uri(request.path)    # will need to fix when moved to api
+                post.origin = request.build_absolute_uri(request.path)    # will need to fix when moved to api
                 post.description = form.cleaned_data.get('description')
                 post.content_text = form.cleaned_data.get('content_text')
                 post.visibility = form.cleaned_data.get('visibility')


### PR DESCRIPTION
Split socialDistribution/models.py into separate files to make code easier to read and maintain. Also changes a few methods to remove excess coupling between some classes (Author and Post)

Removed methods:
- `Post.all_friend_posts()`:
  - Relied on Author class which was causing cyclic import issues. Removed this logic and moved to socialDistribution/views/home since this was the only place this will be used. This move was going to be needed eventually anyways since eventually this will have to be done through API calls.
- `Post.get_latest_posts()`:
  - Similar to the method above, moved logic to socialDistribution/views/home since this was the only place it was used and this logic didn't seem to fit in with the responsibilities of Post since it was too reliant on Authors.
- `author.get_visible_posts_to()`:
  - Removed this because it had too much coupling to Post, and didn't seem like the right place for it. It coupled the current author with another author as well as the entire Post database. This functionality made more sense as an action to be performed by the Post controller, not the author. Moved this logic to the only view in which it was called, socialDistribution/views/author.

Main changes are in socialDistribution/views/author and socialDistribution/views/home. The rest is just file renames and minor stuff caught by the formatter.
