### PR TITLE
Move HOST configuration to .env

### DIFF
--- a/code/cmput404/constants.py
+++ b/code/cmput404/constants.py
@@ -4,7 +4,9 @@ Constants for cmput404 project.
 Defines some constants and path prefixes that are used throughout the project.
 '''
 
-HOST = "127.0.0.1:8000"
+from decouple import config
+
+HOST = config("HOST", "127.0.0.1:8000")
 
 API_PREFIX = "api"
 API_PATH = API_PREFIX + "/"


### PR DESCRIPTION
Allow HOST to be changed from configuration files.
- If deploying on Heroku, set the HOST environment variable to the domain for the deployment
- If deploying a dummy remote server, change the port by changing the HOST variable in .env.