### PR TITLE
Send remote nodes auth credentials on GET as some groups require it 

### DIFF
--- a/code/api/admin.py
+++ b/code/api/admin.py
@@ -2,5 +2,9 @@ from django.contrib import admin
 
 from .models import Node
 
+class NodeAdmin(admin.ModelAdmin):
+    list_filter = ['host', 'remote_credentials']
+    search_fields = ['host']
+
 # Register your models here.
-admin.site.register(Node)
+admin.site.register(Node, NodeAdmin)

--- a/code/api/models.py
+++ b/code/api/models.py
@@ -17,4 +17,9 @@ class Node(models.Model):
     remote_credentials = models.BooleanField(default=False)
 
     def __str__(self):
-        return f'{self.username} - {self.host} - remote:{self.remote_credentials}'
+        return f'{self.host} - remote:{self.remote_credentials}'
+
+    def get_credentials(self):
+        ''' get username and password encoded
+        '''
+        return str.encode(f'{self.username}:{self.password}')

--- a/code/socialDistribution/dispatchers.py
+++ b/code/socialDistribution/dispatchers.py
@@ -8,7 +8,7 @@ def send_post(post: LocalPost, url: str):
     """ Sends a post to the given URL via a POST request. """
 
     data = post.as_json()
-    api_requests.post(url=url, data=data, sendBasicAuthHeader=True)
+    api_requests.post(url=url, data=data, send_basic_auth_header=True)
 
 def dispatch_post(post: LocalPost, recipients: List[LocalAuthor] = None,):
     """ Sends a post to the inbox of all followers who have permission to view the post.
@@ -56,4 +56,4 @@ def dispatch_follow_request(actor: LocalAuthor, object: Author):
         "object": object_json
     }
 
-    api_requests.post(url=object_inbox, data=data, sendBasicAuthHeader=True)
+    api_requests.post(url=object_inbox, data=data, send_basic_auth_header=True)

--- a/code/socialDistribution/requests.py
+++ b/code/socialDistribution/requests.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 def add_auth_header(url, headers):
     '''
-        Add Auth Header for node to header dict
+        Add Auth Header for node to headers dict
     '''
     host = url_parser.get_host(url)
     auth_credentials = node_manager.get_credentials(host=host, remote_credentials=True)

--- a/code/socialDistribution/requests.py
+++ b/code/socialDistribution/requests.py
@@ -18,7 +18,7 @@ from api.parsers import url_parser
 logger = logging.getLogger(__name__)
 
 
-def get(url, params=None):
+def get(url, params=None, basicAuthCredentials=None):
     """ Makes a GET request at the given URL and returns the JSON body of the HTTP response.
 
         Parameters:
@@ -33,6 +33,11 @@ def get(url, params=None):
     headers = {
         "Accept": "application/json"
     }
+
+    # add auth credentials if getting remote node data as some may require it
+    if basicAuthCredentials:
+        authToken = base64.b64encode(basicAuthCredentials).decode("ascii")
+        headers['Authorization'] = 'Basic %s' % authToken
 
     # ref: https://stackoverflow.com/questions/15431044/can-i-set-max-retries-for-requests-request - datashaman
     # 'Can I set max_retries for requests.request?'

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -341,7 +341,7 @@ def authors(request):
 
         # get request for authors
         try:
-            res_code, res_body = api_requests.get(f'http://{node.host}{node.api_prefix}/authors/', basicAuthCredentials=node.get_credentials())
+            res_code, res_body = api_requests.get(f'http://{node.host}{node.api_prefix}/authors/', send_basic_auth_header=True)
 
             # skip node if unresponsive
             if res_body == None:
@@ -598,7 +598,7 @@ def like_post(request, id, post_host):
         }
 
         # redirect request to remote/local api
-        status_code, response_data = api_requests.post(url=request_url, data=like, sendBasicAuthHeader=True)
+        status_code, response_data = api_requests.post(url=request_url, data=like, send_basic_auth_header=True)
 
         if status_code >= 400:
             messages.error(request, 'An error occurred while liking post')
@@ -659,7 +659,7 @@ def like_comment(request, id):
 
     # redirect request to remote/local api
     request_url = f'{SCHEME}://{host}/api/author/{comment.author.id}/inbox/'
-    api_requests.post(url=request_url, data=like, sendBasicAuthHeader=True)
+    api_requests.post(url=request_url, data=like, send_basic_auth_header=True)
 
     if prev_page is None:
         return redirect('socialDistribution:home')

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -341,7 +341,7 @@ def authors(request):
 
         # get request for authors
         try:
-            res_code, res_body = api_requests.get(f'http://{node.host}{node.api_prefix}/authors/')
+            res_code, res_body = api_requests.get(f'http://{node.host}{node.api_prefix}/authors/', basicAuthCredentials=node.get_credentials())
 
             # skip node if unresponsive
             if res_body == None:


### PR DESCRIPTION
Olivier and I noticed that some groups require the auth credentials for getting from all API routes so this pr. 
Abram, says it's not mandatory to require it for all routes other than the inbox route.  
We can also filter/search nodes on the admin panel. 
Review appreciated as Olivier has to deploy for us.