### PR TITLE
Fetch public posts through api calls

### DIFF
--- a/code/api/utility.py
+++ b/code/api/utility.py
@@ -12,13 +12,10 @@ def getPaginated(data, page, size):
     except:
         return []
     
-def makePost(author_id, data):
+def makePost(data):
     """ 
     Creates an InboxPost given json data and adds it to the given author_id's inbox
     """
-    
-    # get owner of inbox
-    receiving_author = get_object_or_404(LocalAuthor, id=author_id)
 
     # save the received post as an InboxPost
     received_post, post_created = InboxPost.objects.get_or_create(
@@ -62,5 +59,4 @@ def makePost(author_id, data):
         category_obj = Category.objects.get(category=category)
         received_post.categories.remove(category_obj)
 
-    # add post to inbox of author
-    receiving_author.inbox_posts.add(received_post)
+    return received_post

--- a/code/api/views.py
+++ b/code/api/views.py
@@ -553,7 +553,14 @@ class InboxView(View):
             if str(data["type"]).lower() == "post":
                 logger.info("Inbox object identified as post")
 
-                makePost(author_id, data)
+                received_post = makePost(data)
+                
+                # get owner of inbox
+                receiving_author = get_object_or_404(LocalAuthor, id=author_id)
+
+                # add post to inbox of author
+                receiving_author.inbox_posts.add(received_post)
+
                 return HttpResponse(status=200)
 
             elif str(data["type"]).lower() == "follow":

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -404,10 +404,10 @@ def author(request, author_id):
                 if post:
                     makePost(post)
 
-            posts = InboxPost.objects.filter(
-                author=author.get_url_id(),
-                visibility=InboxPost.Visibility.PUBLIC
-            )
+        posts = InboxPost.objects.filter(
+            author=author.get_url_id(),
+            visibility=InboxPost.Visibility.PUBLIC
+        )
 
     context = {
         'author': author,

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -402,7 +402,7 @@ def author(request, author_id):
         if res_code == 200 and res_body:
             for post in res_body["items"]:
                 if post:
-                    makePost(curr_user.id, post)
+                    makePost(post)
 
             posts = InboxPost.objects.filter(
                 author=author.get_url_id(),

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -17,6 +17,7 @@ import base64
 
 import socialDistribution.requests as api_requests
 from api.models import Node
+from api.utility import makePost
 from .models import *
 from .forms import CreateUserForm, PostForm
 from .decorators import unauthenticated_user
@@ -389,14 +390,24 @@ def author(request, author_id):
         author_type = REMOTE
 
     if author_type == LOCAL:
-            posts = author.posts.listed().get_public()  # get public posts only
+        posts = author.posts.listed().get_public()  # get public posts only
 
     else:
         # show public posts only
-        posts = InboxPost.objects.filter(
-            author=author.get_url_id(),
-            visibility=InboxPost.Visibility.PUBLIC
-        )
+
+        request_url = author.get_url_id().strip('/') + "/posts"
+
+        res_code, res_body = api_requests.get(request_url, send_basic_auth_header=True)
+        
+        if res_code == 200 and res_body:
+            for post in res_body["items"]:
+                if post:
+                    makePost(curr_user.id, post)
+
+            posts = InboxPost.objects.filter(
+                author=author.get_url_id(),
+                visibility=InboxPost.Visibility.PUBLIC
+            )
 
     context = {
         'author': author,


### PR DESCRIPTION
Make API call to remote authors posts endpoint to retrieve public post to display

![image](https://user-images.githubusercontent.com/59672031/143528021-f9c179b4-93bf-41bc-8a3a-c60cbad0dad7.png)

After the api call, I reused the makePost function which gets or creates inbox posts.