### PR TITLE
POST request error handling

### DIFF
--- a/code/cmput404/settings.py
+++ b/code/cmput404/settings.py
@@ -181,6 +181,10 @@ LOGGING = {
             'handlers': ['custom'],
             'propagate': False,
         },
+        'socialDistribution.dispatchers': {
+            'handlers': ['custom'],
+            'propagate': False,
+        },
         'socialDistribution.utility': {
             'handlers': ['custom'],
             'propagate': False,

--- a/code/cmput404/settings.py
+++ b/code/cmput404/settings.py
@@ -177,6 +177,10 @@ LOGGING = {
             'handlers': ['custom'],
             'propagate': False,
         },
+        'socialDistribution.requests': {
+            'handlers': ['custom'],
+            'propagate': False,
+        },
         'socialDistribution.utility': {
             'handlers': ['custom'],
             'propagate': False,

--- a/code/socialDistribution/dispatchers.py
+++ b/code/socialDistribution/dispatchers.py
@@ -1,11 +1,14 @@
 from typing import List
-
+import logging
 
 import socialDistribution.requests as api_requests
 from .models import LocalPost, Author, LocalAuthor
 
+logger = logging.getLogger(__name__)
+
 def send_post(post: LocalPost, url: str):
     """ Sends a post to the given URL via a POST request. """
+    logger.info(f"Sending post {post.get_id()} to {url}")
 
     data = post.as_json()
     api_requests.post(url=url, data=data, send_basic_auth_header=True)
@@ -55,6 +58,8 @@ def dispatch_follow_request(actor: LocalAuthor, object: Author):
         return False
 
     object_inbox = object.get_inbox()
+
+    logger.info(f"Sending follow request from {actor.get_url_id()} to {object_inbox}")
 
     data = {
         "type": "Follow",

--- a/code/socialDistribution/requests.py
+++ b/code/socialDistribution/requests.py
@@ -73,7 +73,8 @@ def get(url, params=None, send_basic_auth_header=False):
                         status_forcelist=[500, 502, 503, 504])
         session.mount(url, HTTPAdapter(max_retries=retries))
 
-        response = session.get(url, headers=headers, params=params)
+        # timeout here since may need to wake up other groups heroku servers
+        response = session.get(url, headers=headers, params=params, timeout=3)
 
         # parse JSON response if OK
         if response.status_code == 200:


### PR DESCRIPTION
- wrapped the POST api call in a try-except so that the app won't crash if there is a timeout or unable to connect
- added logging for all errors 
- also added logs for dispatchers

Note that you can do a text search for these errors by searching for the module_name.file_name

Examples
```
[2021-11-26 11:00:16,379] INFO socialDistribution.requests: API POST request to http://127.0.0.1:8080/api/author/1/inbox/ and received 200
```

```
[2021-11-26 11:00:16,342] INFO socialDistribution.dispatchers: Sending follow request from http://127.0.0.1:8000/api/author/1 to http://127.0.0.1:8080/api/author/1/inbox/
```

```
[2021-11-26 11:00:16,342] INFO socialDistribution.dispatchers: Sending post http://127.0.0.1:8000/api/author/1/posts/3 to http://127.0.0.1:8080/api/author/1/inbox/
```

Resolves #212 