### PR TITLE
Bug Fix for 401 Unauthorized Errors with T16

### DIFF
--- a/code/socialDistribution/models/post.py
+++ b/code/socialDistribution/models/post.py
@@ -407,7 +407,7 @@ class InboxPost(Post):
     @property
     def comments_as_json(self):
         request_url = self.public_id.strip('/') + '/comments'
-        status_code, response_data = api_requests.get(request_url, send_basic_auth_header=True)
+        status_code, response_data = api_requests.get(request_url)
         if status_code == 200 and response_data is not None:
             comments = response_data["comments"]
             return comments
@@ -417,7 +417,7 @@ class InboxPost(Post):
     @property
     def author_as_json(self):
         request_url = self.public_id.strip('/')
-        status_code, response_data = api_requests.get(request_url, send_basic_auth_header=True)
+        status_code, response_data = api_requests.get(request_url)
         if status_code == 200 and response_data is not None:
             author = response_data["author"]
             return author

--- a/code/socialDistribution/requests.py
+++ b/code/socialDistribution/requests.py
@@ -98,7 +98,7 @@ def get(url, params=None, send_basic_auth_header=True):
     return response.status_code, parse_res_to_dict(response_data)
 
 
-def post(url, params=None, data={}, send_basic_auth_header=False):
+def post(url, params=None, data={}, send_basic_auth_header=True):
     """ Makes a POST request at the given URL and returns the JSON body of the HTTP response.
 
         Parameters:
@@ -145,7 +145,7 @@ def post(url, params=None, data={}, send_basic_auth_header=False):
     # caller should check status codes show error message to user (if needed)
     return response.status_code, response_data
 
-def delete(url, params=None, send_basic_auth_header=False):
+def delete(url, params=None, send_basic_auth_header=True):
     """ Makes a DELETE request at the given URL and returns the JSON body of the HTTP response.
 
         Parameters:

--- a/code/socialDistribution/requests.py
+++ b/code/socialDistribution/requests.py
@@ -43,7 +43,7 @@ def add_auth_header(url, headers):
         headers['Authorization'] = 'Basic %s' % authToken
 
 
-def get(url, params=None, send_basic_auth_header=False):
+def get(url, params=None, send_basic_auth_header=True):
     """ Makes a GET request at the given URL and returns the JSON body of the HTTP response.
 
         Parameters:

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -627,7 +627,7 @@ def like_post(request, post_type, id):
         }
 
         # redirect request to remote/local api
-        status_code, response_data = api_requests.post(url=request_url, data=like, send_basic_auth_header=True)
+        status_code, response_data = api_requests.post(url=request_url, data=like)
 
         if status_code >= 400:
             messages.error(request, 'An error occurred while liking post')
@@ -734,7 +734,7 @@ def like_comment(request):
 
         # redirect request to remote/local api
         request_url = post_author.get_inbox()
-        api_requests.post(url=request_url, data=like, send_basic_auth_header=True)
+        api_requests.post(url=request_url, data=like)
 
 
     if prev_page is None:
@@ -789,7 +789,7 @@ def post_comment(request, author_id, post_id):
                 request_url = f'{post.author.strip("/")}/inbox/'
 
                 # send comment to remote inbox
-                api_requests.post(url=request_url, data=data, send_basic_auth_header=True)
+                api_requests.post(url=request_url, data=data)
 
             else:
                 HttpResponseNotFound()


### PR DESCRIPTION
Turns out we're not sending the auth header on all calls with api_requests.get() like we initially thought. 
Small change so that the default parameters to that `send_basic_auth_header` is true instead of false. 
This should help us work better with T16 https://i-connect.herokuapp.com/service/authors/ which was giving us 401 errors for some endpoints but not others.