### PR TITLE
Catch T16 error

### DIFF
--- a/code/socialDistribution/templatetags/post/post_card.py
+++ b/code/socialDistribution/templatetags/post/post_card.py
@@ -27,6 +27,7 @@ def post_card(post, author):
         like_text = get_like_text(is_liked, likes)
     except:
         is_liked = False
+        likes = 0
         like_text = ''
     
     return {

--- a/code/socialDistribution/templatetags/post/post_card.py
+++ b/code/socialDistribution/templatetags/post/post_card.py
@@ -22,9 +22,12 @@ def post_card(post, author):
         post_type = 'inbox'
     else:
         post_type = 'local'
-    
-    is_liked, likes = get_post_like_info(post, author)
-    like_text = get_like_text(is_liked, likes)
+    try:
+        is_liked, likes = get_post_like_info(post, author)
+        like_text = get_like_text(is_liked, likes)
+    except:
+        is_liked = False
+        like_text = ''
     
     return {
         'post': post,

--- a/code/socialDistribution/templatetags/post/post_card.py
+++ b/code/socialDistribution/templatetags/post/post_card.py
@@ -22,13 +22,10 @@ def post_card(post, author):
         post_type = 'inbox'
     else:
         post_type = 'local'
-    try:
-        is_liked, likes = get_post_like_info(post, author)
-        like_text = get_like_text(is_liked, likes)
-    except:
-        is_liked = False
-        likes = 0
-        like_text = ''
+
+    is_liked, likes = get_post_like_info(post, author)
+    like_text = get_like_text(is_liked, likes)
+
     
     return {
         'post': post,

--- a/code/socialDistribution/utility.py
+++ b/code/socialDistribution/utility.py
@@ -26,13 +26,19 @@ def get_post_like_info(post, author):
             status_code, response_body = api_requests.get(request_url)
 
             if status_code == 200 and response_body is not None:
-                likes_list = response_body["items"]
+                try:
+                    likes_list = response_body["items"]
+                # if we get a KeyError, try treating the body itself as the list of like objects
+                # workaround for T16
+                except KeyError:
+                    likes_list = response_body
 
                 is_liked = False
                 for like in likes_list:
                     if like['id'] == author.get_url_id():
                         is_liked = True
                         break
+                    
 
                 return is_liked, len(likes_list)
 


### PR DESCRIPTION
T16's current /post_id/likes endpoint directly returns a list of like objects rather than `"items": likeObjects`.

T16 will refactor their endpoint after Wednesday. To workaround this in the meantime we catch a KeyError on the response_body and try to treat the response_body itself as a list of like objects. If that fails again then we set the like information to 0 by default to avoid a crash

Resolves #232 - needs testing after deployment