### PR TITLE
Filter friend comments and allow likes on friends/private posts.

### DIFF
--- a/code/api/decorators.py
+++ b/code/api/decorators.py
@@ -50,7 +50,9 @@ def validate_node(view_func):
             return HttpResponseServerError()
 
         if not credentials or token_type != 'Basic' or receivedCredentials != expectedCredentials:
-            return HttpResponse(status=401)
+            response = HttpResponse(status=401)
+            response.headers['WWW-Authenticate'] = "Basic realm='myRealm', charset='UTF-8'"
+            return response
 
         return view_func(request, *args, **kwargs)
 

--- a/code/api/tests/test_likes.py
+++ b/code/api/tests/test_likes.py
@@ -7,10 +7,12 @@ from django.utils import timezone
 from mixer.backend.django import mixer
 
 import json
+import base64
 import logging
 
 from socialDistribution.models import PostLike, CommentLike, Comment, LocalAuthor, LocalPost
-from cmput404.constants import API_BASE
+from cmput404.constants import API_BASE, HOST
+from  api.models import Node
 from .test_post import create_post, get_post_json
 from .test_inbox import create_author
 from datetime import datetime
@@ -202,6 +204,10 @@ class TestCommentLikesView(TestCase):
     @classmethod
     def setUpClass(cls):
         logging.disable(logging.CRITICAL)
+        Node.objects.create(host=HOST, username='testclient', password='testpassword!', remote_credentials=False)
+        cls.basicAuthHeaders = {
+            'HTTP_AUTHORIZATION': 'Basic %s' % base64.b64encode(b'testclient:testpassword!').decode("ascii"),
+        }
 
     # enable logging after tests
     @classmethod
@@ -231,7 +237,10 @@ class TestCommentLikesView(TestCase):
             ]
         }
 
-        response = self.client.get(reverse('api:comment_likes', args=(author1.id, post.id, comment.id,)))
+        response = self.client.get(
+            reverse('api:comment_likes', args=(author1.id, post.id, comment.id,)),
+            **self.basicAuthHeaders
+        )
         self.maxDiff = None
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(json.dumps(expected), response.json())

--- a/code/api/views.py
+++ b/code/api/views.py
@@ -524,6 +524,7 @@ class PostCommentsSingleView(View):
 @method_decorator(csrf_exempt, name='dispatch')
 class CommentLikesView(View):
 
+    @method_decorator(validate_node)
     def get(self, request, author_id, post_id, comment_id):
         """ GET - Get a list of likes on comment_id which 
             was made on post_id which was created by author_id
@@ -535,8 +536,7 @@ class CommentLikesView(View):
             post = get_object_or_404(
                 LocalPost, 
                 id=post_id, 
-                author=author,
-                visibility=LocalPost.Visibility.PUBLIC
+                author=author
             )
             comment = get_object_or_404(Comment, id=comment_id, post=post)
 

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -689,13 +689,19 @@ def single_post(request, post_type, id):
 
     if post_type == "local":
         post = get_object_or_404(LocalPost, id=id)
+        author_is_user = post.author.get_url_id() == current_user.get_url_id()
+        post_author = post.author
     elif post_type == "inbox":
         post = get_object_or_404(InboxPost, id=id)
+        author_is_user = post.author == current_user.get_url_id()
+        post_author = get_object_or_404(Author, url= post.author)
     else:
         raise Http404()
 
     try:
         comments_json = post.comments_as_json
+        comments_to_hide = []
+
         for comment in comments_json:
             # hack 
             # inject more data into json comment
@@ -711,6 +717,8 @@ def single_post(request, post_type, id):
             )
             # add or update remaining fields
             comment_author.update_with_json(data=comment["author"])
+            
+            # get database record of comment_author
             try:
                 author = LocalAuthor.objects.get(url=comment_author.url)
                 author_type = LOCAL
@@ -718,7 +726,19 @@ def single_post(request, post_type, id):
             except LocalAuthor.DoesNotExist:
                 author = get_object_or_404(Author, url=comment_author.url)
                 author_type = REMOTE
+            
+            # Hide comments from other friends of post_author
+            if post.visibility == LocalPost.Visibility.FRIENDS and not author_is_user:
 
+                # if not a friend return
+                if not current_user.has_friend(post_author):
+                    return HttpResponseForbidden("You don't permsission to see this friends only post.")
+                
+                # check if comment from post_author or current user
+                if author.id != post_author.id  and author.id != current_user.id:
+                    comments_to_hide.append(comment)
+                    continue
+                
             comment["comment_author_local_server_id"] = author.id
             comment["comment_author_object"] = comment_author
             comment["author_type"] = author_type
@@ -726,6 +746,11 @@ def single_post(request, post_type, id):
             # add comment time
             now = datetime.now(timezone.utc)
             comment["when"] = timeago.format(datetime.fromisoformat(comment['published']), now)
+
+        # hide comments
+        for comment in comments_to_hide:
+            # del comments_json[index]
+            comments_json.remove(comment)
 
     except Exception as e:
         logger.error(e, exc_info=True)


### PR DESCRIPTION
Resolves #5 
Now on a friends-only post a friend cannot see comments from other friends of the author.