### PR TITLE
Fix remote like

### DIFF
--- a/code/api/views.py
+++ b/code/api/views.py
@@ -202,11 +202,6 @@ class FollowersSingleView(View):
         except (Author.DoesNotExist, Follow.DoesNotExist):
             # return 404 if author not found
             return HttpResponseNotFound()
-        
-    def put(self, request, author_id, foreign_author_id):
-        """ PUT - Add a follower (must be authenticated)"""
-        return NotImplementedError
-
 
 @method_decorator(csrf_exempt, name='dispatch')
 class LikedView(View):

--- a/code/cmput404/settings.py
+++ b/code/cmput404/settings.py
@@ -68,7 +68,6 @@ CORS_ALLOWED_ORIGINS = [
     "https://cmput404fall21g11.herokuapp.com",
     "https://cmput404-bettersocial.herokuapp.com",
     "https://i-connect.herokuapp.com",
-    "http://127.0.0.1:8001",
 ]
 
 TEMPLATES = [

--- a/code/cmput404/settings.py
+++ b/code/cmput404/settings.py
@@ -67,7 +67,8 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:8011",
     "https://cmput404fall21g11.herokuapp.com",
     "https://cmput404-bettersocial.herokuapp.com",
-    "https://i-connect.herokuapp.com"
+    "https://i-connect.herokuapp.com",
+    "http://127.0.0.1:8001",
 ]
 
 TEMPLATES = [

--- a/code/cmput404/settings.py
+++ b/code/cmput404/settings.py
@@ -67,7 +67,7 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:8011",
     "https://cmput404fall21g11.herokuapp.com",
     "https://cmput404-bettersocial.herokuapp.com",
-    "https://i-connect.herokuapp.com",
+    "https://i-connect.herokuapp.com"
 ]
 
 TEMPLATES = [

--- a/code/socialDistribution/utility.py
+++ b/code/socialDistribution/utility.py
@@ -35,7 +35,7 @@ def get_post_like_info(post, author):
 
                 is_liked = False
                 for like in likes_list:
-                    if like['authors']['id'] == author.get_url_id():
+                    if like['author']['id'] == author.get_url_id():
                         is_liked = True
                         break
                     

--- a/code/socialDistribution/utility.py
+++ b/code/socialDistribution/utility.py
@@ -35,7 +35,7 @@ def get_post_like_info(post, author):
 
                 is_liked = False
                 for like in likes_list:
-                    if like['id'] == author.get_url_id():
+                    if like['authors']['id'] == author.get_url_id():
                         is_liked = True
                         break
                     


### PR DESCRIPTION
Error:
![image](https://user-images.githubusercontent.com/24640479/144320719-c879e5ff-516b-40b8-b715-4f3897313b13.png)


Fix:
When getting likes for a remote post we were parsing the like json object incorrectly. Fixed it by first accessing 'author' of a like object before 'id' using `like['author']['id']`

Example like object
`{
         "@context":"https://www.w3.org/ns/activitystreams",
         "summary":"test1 Likes your post",
         "type":"Like",
         "author":{
            "type":"author",
            "id":"http://127.0.0.1:8000/api/author/5e9f3bb2-dcf7-435a-b829-5831a1141ee7",
            "host":"http://127.0.0.1:8000/api/",
            "displayName":"test1",
            "url":"http://127.0.0.1:8000/api/author/5e9f3bb2-dcf7-435a-b829-5831a1141ee7",
            "github":"",
            "profileImage":""
         },
         "object":"http://127.0.0.1:8000/api/author/5e9f3bb2-dcf7-435a-b829-5831a1141ee7/posts/203c2301-ac43-47fd-9202-5be96a808a5c"
      }`