### PR TITLE
inbox posts don't have share or copy link button in modal

### DIFF
--- a/code/socialDistribution/templates/tagtemplates/post.html
+++ b/code/socialDistribution/templates/tagtemplates/post.html
@@ -52,7 +52,7 @@
                                 class="fas fa-comment"></i></button></a>
 
                     <!-- Launch Share Modal -->
-                    {% if is_public or is_friends %}
+                    {% if is_public or is_friends and post_type != 'inbox' %}
                     <button 
                         type="button" 
                         class="btn btn btn-secondary mx-2" 
@@ -62,14 +62,17 @@
                     </button>
                     {% endif %}
                     
+                    {% if post_type != 'inbox' %}
                     <!-- Copy Post Link -->
                     <button 
-                    type="button" 
-                    class="btn btn-secondary mx-1" 
-                    data-bs-toggle="modal" 
-                    data-bs-target="#copy_link_modal{{ post.id }}">
-                        <i class="far fa-copy"></i>
+                        type="button" 
+                        class="btn btn-secondary mx-1" 
+                        data-bs-toggle="modal" 
+                        data-bs-target="#copy_link_modal{{ post.id }}">
+                            <i class="far fa-copy"></i>
+                            {{post_type}}
                     </button>
+                    {% endif %}
 
                     
 


### PR DESCRIPTION
#240 
Please review to make sure i interpreted it correctly. Posts of type "InboxPost" will not have share or copy buttons on the post. But LocalPosts shared with friends still have those buttons.