### PR TITLE
Prevent app crash on t11 post with comments

### DIFF
--- a/code/socialDistribution/models/post.py
+++ b/code/socialDistribution/models/post.py
@@ -419,8 +419,19 @@ class InboxPost(Post):
         request_url = self.public_id.strip('/') + '/comments'
         status_code, response_data = api_requests.get(request_url)
         if status_code == 200 and response_data is not None:
-            comments = response_data["comments"]
-            return comments
+            if "comments" in response_data:
+                comments = response_data["comments"]
+            elif "items" in response_data:
+                # group 11 sends "items" instead 
+                comments = response_data["items"]
+            else:
+                comments = []
+
+            # check if a list 
+            if not type(comments) == list:
+                return []
+            else:
+                return comments
         else:
             return []
         

--- a/code/socialDistribution/templates/tagtemplates/notification_card.html
+++ b/code/socialDistribution/templates/tagtemplates/notification_card.html
@@ -3,6 +3,7 @@
         <p class="h5">
             {{header}}
         </p>
+        <span class="badge normal-white-space bg-dark">{{sender.get_url_id}}</span>
     </div>
     <div class="card-body d-flex flex-row justify-content-end">
         <form method="POST" action="{% url action_link sender.id 'decline' %}">

--- a/code/socialDistribution/templatetags/comment.py
+++ b/code/socialDistribution/templatetags/comment.py
@@ -32,7 +32,7 @@ def comment_card(*args, **kwargs):
     is_friend = author.has_friend(comment_author)
 
     # comment like data
-    is_liked, likes = get_comment_like_info(comment["id"], author)
+    is_liked, likes = get_comment_like_info(comment, author)
     like_text = get_like_text(is_liked, likes)
 
     return {

--- a/code/socialDistribution/utility.py
+++ b/code/socialDistribution/utility.py
@@ -48,7 +48,7 @@ def get_post_like_info(post, author):
         logger.error(e, exc_info=True)
         return None, 0
 
-def get_comment_like_info(comment_id, author):
+def get_comment_like_info(comment, author):
     """
     Returns a boolean indicating whether the author parameter
     liked the comment with id of comment_id, and an integer representing the
@@ -58,6 +58,7 @@ def get_comment_like_info(comment_id, author):
     """
     try:
         print(__name__)
+        comment_id = comment["id"]
         request_url = comment_id.strip('/') + '/likes'
         status_code, response_body = api_requests.get(request_url)
 


### PR DESCRIPTION
Unfortunately crashes on visiting: https://social-distribution-fall2021.herokuapp.com/app/posts/inbox/29829d6a-8e52-4bfd-a42d-e5288682e93f/
They don't follow the spec hence we have to check.