### PR TITLE
Cleanup API

### DIFF
--- a/code/api/decorators.py
+++ b/code/api/decorators.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
-from django.http.response import HttpResponseServerError
+from django.http.response import HttpResponseBadRequest, HttpResponseForbidden, HttpResponseServerError
 from django.shortcuts import get_object_or_404
+from django.contrib.auth import authenticate
 from .models import Node
 from socialDistribution.models import LocalAuthor
 from .node_manager import node_manager
@@ -9,22 +10,35 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def authenticate_request(view_func):
+def validate_user(view_func):
     """
         Restrict API path to only {author_id}
     """
     def wrapper_func(request, author_id, *args, **kwargs):
-        # check if user f authenticated
-        if not request.user.is_authenticated:
-            return HttpResponse(status=401)
+        
+        try:
+            auth_header = request.META.get('HTTP_AUTHORIZATION')
+            if auth_header is None:
+                return HttpResponse(status=401)
+            token_type, _, receivedCredentials = auth_header.partition(' ')
+            username, password = base64.b64decode(receivedCredentials).decode().split(':')
 
-        author = get_object_or_404(LocalAuthor, user=request.user)
+            # Django Software Foundation, "Authenticating users", 2021-12-04
+            # https://docs.djangoproject.com/en/3.2/topics/auth/default/#authenticating-users
+            user = authenticate(username=username, password=password)
+            if token_type != 'Basic' or user is None:
+                response = HttpResponse(status=401)
+                response.headers['WWW-Authenticate'] = "Basic realm='myRealm', charset='UTF-8'"
+                return response
 
-        # check if user is allowed to view resource
-        requestId = str(author.id)
-        authorId = str(author_id)
-        if requestId != authorId:
-            return HttpResponse(status=403)
+            # check if user matches the requested author
+            author = LocalAuthor.objects.get(user=user)
+            if author.id != author_id:
+                return HttpResponseForbidden()
+
+
+        except Exception as e:
+            return HttpResponseBadRequest()
 
         return view_func(request, author_id, *args, **kwargs)
 
@@ -46,7 +60,7 @@ def validate_node(view_func):
             credentials = node_manager.get_credentials(username=username, remote_credentials=False)
             expectedCredentials = base64.b64encode(credentials).decode()
         except Exception as e:
-            logger.error(str(e))
+            logger.error(e)
             return HttpResponseServerError()
 
         if not credentials or token_type != 'Basic' or receivedCredentials != expectedCredentials:

--- a/code/api/decorators.py
+++ b/code/api/decorators.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-from django.http.response import HttpResponseBadRequest, HttpResponseForbidden, HttpResponseServerError
+from django.http.response import Http404, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import get_object_or_404
 from django.contrib.auth import authenticate
 from .models import Node
@@ -32,11 +32,14 @@ def validate_user(view_func):
                 return response
 
             # check if user matches the requested author
-            author = LocalAuthor.objects.get(user=user)
-            if author.id != author_id:
+            expected = get_object_or_404(LocalAuthor, id=author_id)
+            actual = LocalAuthor.objects.get(user=user)
+            if expected != actual:
                 return HttpResponseForbidden()
 
-
+        except Http404:
+            return HttpResponseNotFound()
+            
         except Exception as e:
             return HttpResponseBadRequest()
 

--- a/code/api/tests/test_authors.py
+++ b/code/api/tests/test_authors.py
@@ -8,6 +8,7 @@ import json
 import logging
 
 from socialDistribution.models import LocalAuthor
+from .utilities import create_author as create_author_with_auth, get_basic_auth
 
 # Documentation and code samples taken from the following references:
 # Django Software Foundation, https://docs.djangoproject.com/en/3.2/intro/tutorial05/
@@ -263,3 +264,45 @@ class AuthorsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(actual, expected)
+
+    def test_post_author(self):
+        author = create_author_with_auth()
+
+        data = {
+            "displayName": "Lara Croft",
+            "github": "https://github.com/croft",
+            "profileImage": "https://lh4.googleusercontent.com/-qu9N5sJB6Uc/TXdJsP9YGOI/AAAAAAAAAZs/AIta6Ea3XVU/s1600/TR3.jpg"
+        }
+
+        # make post to update author object
+        response = self.client.post(
+            reverse("api:author", kwargs={"author_id": author.id}),
+            content_type="application/json",
+            data=json.dumps(data),
+            **get_basic_auth(author)
+        )
+
+        self.assertEqual(200, response.status_code)
+
+        actual = response.json()
+        self.assertEqual(actual["displayName"], data["displayName"])
+        self.assertEqual(actual["github"], data["github"])
+        self.assertEqual(actual["profileImage"], data["profileImage"])
+
+    def test_no_auth(self):
+        author = create_author_with_auth()
+
+        data = {
+            "displayName": "Lara Croft",
+            "github": "https://github.com/croft",
+            "profileImage": "https://lh4.googleusercontent.com/-qu9N5sJB6Uc/TXdJsP9YGOI/AAAAAAAAAZs/AIta6Ea3XVU/s1600/TR3.jpg"
+        }
+
+        # make post to update author object
+        response = self.client.post(
+            reverse("api:author", kwargs={"author_id": author.id}),
+            content_type="application/json",
+            data=json.dumps(data)
+        )
+
+        self.assertEqual(401, response.status_code)

--- a/code/api/tests/test_inbox.py
+++ b/code/api/tests/test_inbox.py
@@ -14,6 +14,7 @@ from socialDistribution.models import LocalAuthor, LocalPost, Comment, Author
 from api.models import Node
 from cmput404.constants import API_BASE, HOST
 import base64
+from .utilities import create_author as create_author_simple, get_basic_auth
 
 # Documentation and code samples taken from the following references:
 # Django Software Foundation, https://docs.djangoproject.com/en/3.2/intro/tutorial05/
@@ -118,7 +119,7 @@ class InboxViewTests(TestCase):
 
         # Create a post from author1
         dummy_post = mixer.blend(
-            LocalPost, 
+            LocalPost,
             author=author1,
             content="testcontent".encode("utf-8")
         )
@@ -143,24 +144,17 @@ class InboxViewTests(TestCase):
         self.assertEqual(inbox_post.title, dummy_post.title)
         self.assertEqual(inbox_post.description, dummy_post.description)
         self.assertEqual(inbox_post.decoded_content, dummy_post.decoded_content)
-        
+
     def test_get_inbox(self):
         self.maxDiff = None
-        author1 = create_author(
-            "user1",
-            "Greg Johnson",
-            "http://github.com/gjohnson"
-        )
-        author2 = create_author(
-            "user2",
-            "Lara Croft",
-            "http://github.com/laracroft"
-        )
+        author1 = create_author_simple()
+
+        author2 = create_author_simple()
 
         # Create a post from author1
         dummy_post = mixer.blend(
-            LocalPost, 
-            id=1, 
+            LocalPost,
+            id=1,
             author=author1,
             content="testcontent".encode("utf-8")
         )
@@ -176,21 +170,20 @@ class InboxViewTests(TestCase):
         )
 
         # Check the inbox of author2
-        self.client.login(username='user2', password='password')
         response = self.client.get(
             reverse("api:inbox", kwargs={"author_id": author2.id}),
             content_type="application/json",
-            **self.basicAuthHeaders,
+            **get_basic_auth(author2),
         )
 
-        res_data = json.loads(response.content)
-     
-        resPost = res_data["items"][0]
         self.assertEqual(response.status_code, 200)
+
+        res_data = json.loads(response.content)
+        resPost = res_data["items"][0]
         self.assertEqual(resPost['title'], dummy_post.title)
         self.assertEqual(resPost['description'], dummy_post.description)
         self.assertEqual(resPost['content'], dummy_post.decoded_content)
-    
+
     def test_post_comment_local_like(self):
         '''
             Test liking a comment from a local author
@@ -199,17 +192,17 @@ class InboxViewTests(TestCase):
             "user1",
             "Greg Johnson",
             "http://github.com/gjohnson"
-        ) 
+        )
 
-        post = mixer.blend(LocalPost, author = author1)
-        comment = mixer.blend(Comment, author=author1, post=post, pub_date = datetime.now(timezone.utc) )
+        post = mixer.blend(LocalPost, author=author1)
+        comment = mixer.blend(Comment, author=author1, post=post, pub_date=datetime.now(timezone.utc))
 
         body = {
-                   "@context": "https://www.w3.org/ns/activitystreams",
-                    "summary": f"{author1.username} Likes your post",         
-                    "type": "Like",
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "summary": f"{author1.username} Likes your post",
+            "type": "Like",
                     "author": author1.as_json(),
-                    "object":f"http://{HOST}/author/{post.author.id}/posts/{post.id}/comments/{comment.id}"
+                    "object": f"http://{HOST}/author/{post.author.id}/posts/{post.id}/comments/{comment.id}"
         }
 
         response = self.client.post(
@@ -218,7 +211,6 @@ class InboxViewTests(TestCase):
             **self.basicAuthHeaders,
             data=body
         )
-        
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(comment.total_likes(), 1)
@@ -258,7 +250,7 @@ class InboxViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        
+
         # Check that the post received a like
         post = LocalPost.objects.get(id=post.id)
         self.assertEqual(1, post.likes.count())

--- a/code/api/tests/test_post.py
+++ b/code/api/tests/test_post.py
@@ -1,34 +1,33 @@
 # python manage.py test api
 
-from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 from mixer.backend.django import mixer
+import base64
 
 import json
 import logging
 import uuid
 
-from socialDistribution.models import LocalPost, Category, LocalAuthor
-from .test_authors import create_author
+from socialDistribution.models import LocalPost, LocalAuthor
 from cmput404.constants import API_BASE
-from datetime import datetime
+from .utilities import create_author, get_basic_auth
+
 
 def create_post(title, author):
     post = LocalPost.objects.create(
-            author_id=author.id,
-            title=title,
-            description="testDesc",
-            content_type=LocalPost.ContentType.PLAIN,
-            content="testContexxt".encode("utf-8"),
-            visibility=LocalPost.Visibility.PUBLIC,
-            unlisted=False,
-        )
+        author_id=author.id,
+        title=title,
+        description="testDesc",
+        content_type=LocalPost.ContentType.PLAIN,
+        content="testContexxt".encode("utf-8"),
+        visibility=LocalPost.Visibility.PUBLIC,
+        unlisted=False,
+    )
     post.origin = post.get_id()
     post.source = post.get_id()
     post.save()
-    
+
     return post
 
 
@@ -36,23 +35,24 @@ def get_post_json(post):
     previousCategories = post.categories.all()
     previousCategoriesNames = [cat.category for cat in previousCategories]
     return {
-            "type":"post",
-            "title":post.title,
-            "id": f"{API_BASE}/author/{post.author.id}/posts/{post.id}",
-            "source": f"{API_BASE}/author/{post.author.id}/posts/{post.id}",
-            "origin": f"{API_BASE}/author/{post.author.id}/posts/{post.id}",
-            "description":post.description,
-            "contentType":post.get_content_type_display(),
-            "content":post.content,
-            "author":post.author.as_json(),
-            "categories":previousCategoriesNames,
-            "count": 0,
-            "comments":f"{API_BASE}/author/{post.author.id}/posts/{post.id}/comments/",
-            "commentsSrc":post.recent_comments_json,
-            "published":post.published.isoformat(),
-            "visibility":post.get_visibility_display(),
-            "unlisted":post.unlisted
-        }
+        "type": "post",
+        "title": post.title,
+        "id": f"{API_BASE}/author/{post.author.id}/posts/{post.id}",
+        "source": f"{API_BASE}/author/{post.author.id}/posts/{post.id}",
+        "origin": f"{API_BASE}/author/{post.author.id}/posts/{post.id}",
+        "description": post.description,
+        "contentType": post.get_content_type_display(),
+        "content": post.content,
+        "author": post.author.as_json(),
+        "categories": previousCategoriesNames,
+        "count": 0,
+        "comments": f"{API_BASE}/author/{post.author.id}/posts/{post.id}/comments/",
+        "commentsSrc": post.recent_comments_json,
+        "published": post.published.isoformat(),
+        "visibility": post.get_visibility_display(),
+        "unlisted": post.unlisted
+    }
+
 
 class PostViewTest(TestCase):
 
@@ -69,6 +69,11 @@ class PostViewTest(TestCase):
     def tearDownClass(cls):
         logging.disable(logging.NOTSET)
 
+    def setUp(self):
+        self.basicAuthHeaders = {
+            'HTTP_AUTHORIZATION': 'Basic %s' % base64.b64encode(b'testuser:123456!').decode("ascii"),
+        }
+
     def test_get_post_basic(self):
         self.maxDiff = None
         author = mixer.blend(LocalAuthor)
@@ -76,42 +81,54 @@ class PostViewTest(TestCase):
         expected = get_post_json(post)
         expected['content'] = expected['content'].decode('utf-8')
 
-        response = self.client.get(reverse('api:post', args=(post.author.id,post.id)))
+        response = self.client.get(reverse('api:post', args=(post.author.id, post.id)))
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content, expected)
-        
+
     def test_post_post(self):
         self.maxDiff = None
-        author = mixer.blend(LocalAuthor)
+        author = create_author()
         post = create_post("first", author)
         newJson = get_post_json(post)
         newJson['title'] = 'newPost'
         newJson['content'] = newJson['content'].decode('utf-8')
 
-        response = self.client.post(reverse('api:post', args=(post.author.id,post.id)), content_type="application/json", data=json.dumps(newJson))
+        response = self.client.post(
+            reverse('api:post', args=(post.author.id, post.id)),
+            content_type="application/json",
+            data=json.dumps(newJson),
+            **get_basic_auth(author)
+        )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(newJson['title'], LocalPost.objects.filter(id=post.id).first().title)
-        
+
     def test_put_post(self):
         self.maxDiff = None
-        author = mixer.blend(LocalAuthor)
+        author = create_author()
         post = create_post("first", author)
         newJson = get_post_json(post)
         newJson['title'] = 'newPost'
         newJson['content'] = newJson['content'].decode('utf-8')
         post_id = uuid.uuid4()
 
-        response = self.client.put(reverse('api:post', args=(post.author.id,str(post_id))), content_type="application/json", data=json.dumps(newJson))
+        response = self.client.put(
+            reverse('api:post', args=(post.author.id, str(post_id))),
+            content_type="application/json",
+            **get_basic_auth(author),
+            data=json.dumps(newJson),
+        )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(newJson['title'], LocalPost.objects.latest('published').title)
         self.assertEqual(post_id, LocalPost.objects.latest('published').id)
-        
+
     def test_delete_post(self):
         self.maxDiff = None
-        author = mixer.blend(LocalAuthor)
+        author = create_author()
         post = create_post("first", author)
 
-        response = self.client.delete(reverse('api:post', args=(post.author.id,post.id)))
+        response = self.client.delete(
+            reverse('api:post', args=(post.author.id, post.id)),
+            **get_basic_auth(author)
+        )
         self.assertEqual(response.status_code, 200)
         self.assertFalse(LocalPost.objects.filter(id=post.id).exists())
-        

--- a/code/api/tests/utilities.py
+++ b/code/api/tests/utilities.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import User
+from mixer.backend.django import mixer
+import base64
+from socialDistribution.models import LocalAuthor
+
+TEST_PASSWORD = "123456"
+
+
+def create_author():
+    user = mixer.blend(User)
+    user.set_password(TEST_PASSWORD)
+    user.save()
+    author = LocalAuthor.objects.create(username=user.username, user=user)
+    return LocalAuthor.objects.get(id=author.id)  # refetch to get the generated ID
+
+
+def get_basic_auth(author):
+    username = author.user.username
+    credentials = str.encode(f'{username}:{TEST_PASSWORD}')
+    return {
+        'HTTP_AUTHORIZATION': 'Basic %s' % base64.b64encode(credentials).decode("ascii"),
+    }

--- a/code/api/views.py
+++ b/code/api/views.py
@@ -819,5 +819,7 @@ class InboxView(View):
         """ DELETE - Clear the inbox """
 
         logger.info(f"POST /author/{author_id}/inbox/ API endpoint invoked")
-
-        return HttpResponse("Hello")
+        author = get_object_or_404(LocalAuthor, id=author_id)
+        author.follow_requests.clear()
+        author.inbox_posts.clear()
+        return HttpResponse(status=204)

--- a/code/socialDistribution/templates/user/profile.html
+++ b/code/socialDistribution/templates/user/profile.html
@@ -24,9 +24,10 @@
    <div class="col col-lg-9">
         <form
             method="post"
-            action="{% url 'api:author' author.id %}" 
+            action="{% url 'socialDistribution:profile' %}" 
         >
-            <div class="mb-3">
+        {% csrf_token %}
+        <div class="mb-3">
                 <label for="username" class="form-label">Username</label>
                 <input disabled type="text" class="form-control" name="username" id="username" value="{{ author.username }}">
             </div>

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -687,7 +687,7 @@ def single_post(request, post_type, id):
     elif post_type == "inbox":
         post = get_object_or_404(InboxPost, id=id)
         author_is_user = post.author == current_user.get_url_id()
-        post_author = get_object_or_404(Author, url= post.author)
+        post_author = get_object_or_404(Author, url=post.author)
     else:
         raise Http404()
 
@@ -710,7 +710,7 @@ def single_post(request, post_type, id):
             )
             # add or update remaining fields
             comment_author.update_with_json(data=comment["author"])
-            
+
             # get database record of comment_author
             try:
                 author = LocalAuthor.objects.get(url=comment_author.url)
@@ -719,19 +719,19 @@ def single_post(request, post_type, id):
             except LocalAuthor.DoesNotExist:
                 author = get_object_or_404(Author, url=comment_author.url)
                 author_type = REMOTE
-            
+
             # Hide comments from other friends of post_author
             if post.visibility == LocalPost.Visibility.FRIENDS and not author_is_user:
 
                 # if not a friend return
                 if not current_user.has_friend(post_author):
                     return HttpResponseForbidden("You don't permsission to see this friends only post.")
-                
+
                 # check if comment from post_author or current user
-                if author.id != post_author.id  and author.id != current_user.id:
+                if author.id != post_author.id and author.id != current_user.id:
                     comments_to_hide.append(comment)
                     continue
-                
+
             comment["comment_author_local_server_id"] = author.id
             comment["comment_author_object"] = comment_author
             comment["author_type"] = author_type
@@ -912,6 +912,29 @@ def profile(request):
     '''
     author = get_object_or_404(LocalAuthor, user=request.user)
     djangoUser = get_object_or_404(get_user_model(), username=request.user)
+
+    if request.method == 'POST':
+        # extract post data
+        display_name = request.POST.get('display_name')
+        github_url = request.POST.get('github_url')
+        email = request.POST.get('email')
+        profile_image_url = request.POST.get('profile_image_url')
+
+        try:
+            # update author
+            author.displayName = display_name
+            author.githubUrl = github_url
+            author.profileImageUrl = profile_image_url
+            author.save()
+
+            # update django user
+            djangoUser.email = email
+            djangoUser.save()
+
+        except Exception:
+            return messages.error(request, "Error editing profile")
+
+        return redirect('socialDistribution:profile')
 
     # add missing information to author
     author.email = djangoUser.email

--- a/code/socialDistribution/views.py
+++ b/code/socialDistribution/views.py
@@ -932,9 +932,10 @@ def profile(request):
             djangoUser.save()
 
         except Exception:
-            return messages.error(request, "Error editing profile")
+            messages.error(request, "Error editing profile")
 
-        return redirect('socialDistribution:profile')
+        finally:
+            return redirect('socialDistribution:profile')
 
     # add missing information to author
     author.email = djangoUser.email


### PR DESCRIPTION
- One last look over API
- Add local authentication (using basic auth) so local users can authenticate with API and access authenticated routes
- Add local authentication to some routes
- Move socialDistribution redirect view from /authors/id/ to socialDistribution/views.py
- Fix /author/id POST endpoint to return JSON instead of redirect
- Implement DELETE /inbox route
- Overall clean up and fix tests
- Resolves #273, #22 